### PR TITLE
Add more info to version switch

### DIFF
--- a/test/cli/sbom_cmd_test.go
+++ b/test/cli/sbom_cmd_test.go
@@ -29,6 +29,19 @@ func TestSBOMCmdFlags(t *testing.T) {
 			},
 		},
 		{
+			name: "use-version-option",
+			args: []string{"sbom", "--version"},
+			assertions: []traitAssertion{
+				assertInOutput("Application:"),
+				assertInOutput("docker-sbom ("),
+				assertInOutput("Provider:"),
+				assertInOutput("GitDescription:"),
+				assertInOutput("syft (v0.41.1)"),
+				assertNotInOutput("not provided"),
+				assertSuccessfulReturnCode,
+			},
+		},
+		{
 			name: "json-output-flag",
 			args: []string{"sbom", "-o", "json", coverageImage},
 			assertions: []traitAssertion{


### PR DESCRIPTION
New example output from `docker sbom --version` (from a snapshot build)
```
$ docker sbom --version
Application:        docker-sbom (0.3.0-SNAPSHOT-fbabd2a)
Provider:           syft (v0.41.1)
BuildDate:          2022-03-11T01:04:38Z
GitCommit:          fbabd2aac2a2d670740550cdf5b71a6a6f3ecfe9
GitDescription:     v0.3.0-dirty
Platform:           darwin/amd64
```